### PR TITLE
DTL-7299-fix-type-error

### DIFF
--- a/evaluate-dependencies.js
+++ b/evaluate-dependencies.js
@@ -66,13 +66,12 @@ async function evaluate() {
         core.info('Initializing...');
         const myToken = process.env.GITHUB_TOKEN;
         const maxRetries = parseInt(core.getInput('max-retries') || '3', 10);
-        const MyOctokit = github.getOctokit.plugin(retry);
-        const octokit = new MyOctokit(myToken, {
+        const octokit = github.getOctokit(myToken, {
             retry: {
                 doNotRetry: [],
                 retries: maxRetries
             }
-        });
+        }, retry);
 
         // Log retry attempts
         octokit.hook.before('request', (options) => {


### PR DESCRIPTION
## Description

Fixes a `TypeError: github.getOctokit.plugin is not a function` error that was preventing the action from running.

## Changes

- Updated the Octokit initialization to pass the retry plugin as the third argument to `github.getOctokit()` instead of incorrectly calling `.plugin()` on the `getOctokit` function
- The correct pattern for adding plugins to Octokit via `@actions/github` is: `github.getOctokit(token, options, ...plugins)`

## Testing

Tested locally with:
```bash
env "INPUT_PR-NUMBER=1105" "INPUT_MAX-RETRIES=3" GITHUB_TOKEN=<token> GITHUB_REPOSITORY=pipedrive/dott-test-service node [index.js](http://_vscodecontentref_/0)